### PR TITLE
Support building without RTTI and exceptions

### DIFF
--- a/include/eggs/variant/bad_variant_access.hpp
+++ b/include/eggs/variant/bad_variant_access.hpp
@@ -42,7 +42,11 @@ namespace eggs { namespace variants
         template <typename T>
         EGGS_CXX11_NORETURN inline T throw_bad_variant_access()
         {
+#ifndef EGGS_VARIANT_NO_EXCEPTIONS
             throw bad_variant_access{};
+#else
+            std::terminate();
+#endif
         }
     }
 }}

--- a/include/eggs/variant/detail/visitor.hpp
+++ b/include/eggs/variant/detail/visitor.hpp
@@ -139,6 +139,7 @@ namespace eggs { namespace variants { namespace detail
         }
     };
 
+#ifndef EGGS_VARIANT_NO_RTTI
     struct type_id
       : visitor<type_id, std::type_info const&()>
     {
@@ -148,6 +149,7 @@ namespace eggs { namespace variants { namespace detail
             return typeid(T);
         }
     };
+#endif
 
     template <typename Union>
     struct equal_to

--- a/include/eggs/variant/variant.hpp
+++ b/include/eggs/variant/variant.hpp
@@ -798,6 +798,7 @@ namespace eggs { namespace variants
             return _storage.which() != 0 ? _storage.which() - 1 : npos;
         }
 
+#ifndef EGGS_VARIANT_NO_RTTI
         //! constexpr std::type_info const& target_type() const noexcept;
         //!
         //! \returns If `*this` has an active member of type `T`, `typeid(T)`;
@@ -812,6 +813,7 @@ namespace eggs { namespace variants
                 )
               : typeid(void);
         }
+#endif
 
         //! constexpr void* target() noexcept;
         //!
@@ -900,7 +902,9 @@ namespace eggs { namespace variants
 
         EGGS_CXX11_CONSTEXPR explicit operator bool() const EGGS_CXX11_NOEXCEPT { return false; }
         EGGS_CXX11_CONSTEXPR std::size_t which() const EGGS_CXX11_NOEXCEPT { return npos; }
+#ifndef EGGS_VARIANT_NO_RTTI
         EGGS_CXX11_CONSTEXPR std::type_info const& target_type() const EGGS_CXX11_NOEXCEPT { return typeid(void); }
+#endif
         EGGS_CXX14_CONSTEXPR void* target() EGGS_CXX11_NOEXCEPT { return nullptr; }
         EGGS_CXX11_CONSTEXPR void const* target() const EGGS_CXX11_NOEXCEPT { return nullptr; }
     };


### PR DESCRIPTION
This allows building eggs variant in environment where RTTI and exceptions are disabled.

I didn't really know what to do instead of throwing bad_variant_access, I'm open to suggestions.