### PR TITLE
Require C++14. closes #17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@
 
 project(Eggs.Variant CXX)
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
+
+set (CMAKE_CXX_STANDARD 14)
 
 include_directories(include)
 add_subdirectory(test)


### PR DESCRIPTION
This fixes the constexpr-related compilation errors (C++14 is needed, C++11 does not suffice). 

An alternative fix would be to add c++ version number fixes to the source as macros.