### PR TITLE
[RFC] C++17: Use std::launder to access in-place constructed objects

### DIFF
--- a/include/eggs/variant/detail/storage.hpp
+++ b/include/eggs/variant/detail/storage.hpp
@@ -287,7 +287,7 @@ namespace eggs { namespace variants { namespace detail
             /*is_copy_assignable<Ts...>=*/std::false_type
           , index<I> /*which*/, Args&&... args)
         {
-            T* ptr = ::new (target()) T(detail::forward<Args>(args)...);
+            T* ptr = std::launder(::new (target()) T(detail::forward<Args>(args)...));
             _which = I;
             return *ptr;
         }


### PR DESCRIPTION
According to https://en.cppreference.com/w/cpp/utility/launder and https://stackoverflow.com/questions/39382501/what-is-the-purpose-of-stdlaunder `std::launder` is required whenever one accesses in-place constructed objects. This is one place I found, but there might be more. I did not recognise a defect yet, but you never know.